### PR TITLE
Don't force using u64 in non-x64 platforms

### DIFF
--- a/.changes/fix_32bits_builds.md
+++ b/.changes/fix_32bits_builds.md
@@ -1,0 +1,5 @@
+---
+"sys": patch
+---
+
+Don't force using u64 in non-x64 platforms

--- a/tauri-hotkey-sys/src/linux.rs
+++ b/tauri-hotkey-sys/src/linux.rs
@@ -183,7 +183,7 @@ impl HotkeyListener for Listener {
           }
           match thread_receiver.try_recv() {
             Ok(HotkeyMessage::RegisterHotkey(_, modifiers, key)) => {
-              let keycode = (xlib.XKeysymToKeycode)(display, key as u64) as i32;
+              let keycode = (xlib.XKeysymToKeycode)(display, key.into()) as i32;
 
               let result = (xlib.XGrabKey)(
                 display,


### PR DESCRIPTION
Was thrown when trying to compile in an 32bits system:

![image](https://user-images.githubusercontent.com/3369266/117007859-66aef980-acea-11eb-97c7-fd78995922ea.png)

I could successfully build the lib on my 32bits RPI 3 😉 